### PR TITLE
Speed up script in git repositories

### DIFF
--- a/bash-wakatime.sh
+++ b/bash-wakatime.sh
@@ -13,7 +13,7 @@ pre_prompt_command() {
     version="1.0.0"
     entity=$(echo $(fc -ln -0) | cut -d ' ' -f1)
     [ -z "$entity" ] && return # $entity is empty or only whitespace
-    git status &> /dev/null && local project="$(basename $(git rev-parse --show-toplevel))" || local project="Terminal"
+    git rev-parse --git-dir &> /dev/null && local project="$(basename $(git rev-parse --show-toplevel))" || local project="Terminal"
     (wakatime --write --plugin "bash-wakatime/$version" --entity-type app --project "$project" --entity "$entity" 2>&1 > /dev/null &)
 }
 


### PR DESCRIPTION
I was experiencing Bash hangs on large Git repos in dirty state, because of `git status &> /dev/null` presumably used to detect folders being roots or sub-folders of Git repos

P.S. IMO this issue on my Ubuntu laptop got even worse, because most of Git repositories are located on an NTFS-formatted 5400 RPM HDD (I share this partition with dual-booted Windows 10)