### PR TITLE
Avoid basename error in .git/

### DIFF
--- a/bash-wakatime.sh
+++ b/bash-wakatime.sh
@@ -13,7 +13,7 @@ pre_prompt_command() {
     version="1.0.0"
     entity=$(echo $(fc -ln -0) | cut -d ' ' -f1)
     [ -z "$entity" ] && return # $entity is empty or only whitespace
-    git rev-parse --git-dir &> /dev/null && local project="$(basename $(git rev-parse --show-toplevel))" || local project="Terminal"
+    $(git rev-parse --is-inside-work-tree 2> /dev/null) && local project="$(basename $(git rev-parse --show-toplevel))" || local project="Terminal"
     (wakatime --write --plugin "bash-wakatime/$version" --entity-type app --project "$project" --entity "$entity" 2>&1 > /dev/null &)
 }
 


### PR DESCRIPTION
issue: https://github.com/irondoge/bash-wakatime/issues/10

It works well with checking with `git rev-parse --is-inside-work-tree`
```sh
$ cd /path/to/repository
$ git rev-parse --is-inside-work-tree
true

$ cd .git
$ git rev-parse --is-inside-work-tree
false

$ cd ../../ # move to outside of repository
$ git rev-parse --is-inside-work-tree
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```