### PR TITLE
Update bash-wakatime.sh

### DIFF
--- a/bash-wakatime.sh
+++ b/bash-wakatime.sh
@@ -11,6 +11,7 @@
 # hook function to send wakatime a tick
 pre_prompt_command() {
     version="1.0.0"
+    # shellcheck disable=SC2046,SC2005
     entity=$(echo $(fc -ln -0) | cut -d ' ' -f1)
     [ -z "$entity" ] && return # $entity is empty or only whitespace
     git rev-parse --is-inside-work-tree &> /dev/null && local project="$(basename "$(git rev-parse --show-toplevel)")" || local project="Terminal"

--- a/bash-wakatime.sh
+++ b/bash-wakatime.sh
@@ -13,8 +13,8 @@ pre_prompt_command() {
     version="1.0.0"
     entity=$(echo $(fc -ln -0) | cut -d ' ' -f1)
     [ -z "$entity" ] && return # $entity is empty or only whitespace
-    $(git rev-parse --is-inside-work-tree 2> /dev/null) && local project="$(basename $(git rev-parse --show-toplevel))" || local project="Terminal"
-    (~/.wakatime/wakatime-cli --write --plugin "bash-wakatime/$version" --entity-type app --project "$project" --entity "$entity" 2>&1 > /dev/null &)
+    git rev-parse --is-inside-work-tree &> /dev/null && local project="$(basename "$(git rev-parse --show-toplevel)")" || local project="Terminal"
+    (~/.wakatime/wakatime-cli --write --plugin "bash-wakatime/$version" --entity-type app --project "$project" --entity "$entity" &> /dev/null &)
 }
 
 PROMPT_COMMAND="pre_prompt_command; $PROMPT_COMMAND"


### PR DESCRIPTION
- removed excessive shell invocation in line 16, as you can check the status code of `git rev-parse` instead of the output to get the result
- fixed `shellcheck` complains about quoting
- fixed `wakatime-cli` redirection, see https://github.com/koalaman/shellcheck/wiki/SC2069